### PR TITLE
add bye, clear commands and python interpreter

### DIFF
--- a/ftp.py
+++ b/ftp.py
@@ -92,10 +92,6 @@ clear """)
 
             if cmd == command[11]:
                 os.system("clear")
-<<<<<<< HEAD
-=======
-
->>>>>>> 1b4508b64d490adee5377e0e501eca3d7b52b02b
             if cmd in ('q', 'quit', 'exit', 'bye'):
                 return True
 

--- a/ftp.py
+++ b/ftp.py
@@ -32,17 +32,10 @@ def cli(prompt, reminder='Please type a valid command'):
         cmd = input(prompt)
         try:
             if cmd == command[0]:
-<<<<<<< HEAD
-                print("""
-cd          debug           delete          get         ls
-mkdir       pwd             rmdir           send        size
-clear """)
-=======
                 all_commands = command[:]
                 all_commands.sort()
                 print(*all_commands[0:6], sep='\t')
                 print(*all_commands[6:12], sep='\t')
->>>>>>> 943ee5eabe6c8fcbdd5bc7f8e6d6ef0e1d97d560
 
             if cmd == command[1]:
                 ftp.dir()

--- a/ftp.py
+++ b/ftp.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 from ftplib import FTP
@@ -32,7 +35,7 @@ def cli(prompt, reminder='Please type a valid command'):
                 print("""
 cd          debug           delete          get         ls
 mkdir       pwd             rmdir           send        size
-""")
+clear """)
             if cmd == command[1]:
                 ftp.dir()
             if cmd == command[2]:
@@ -63,7 +66,7 @@ mkdir       pwd             rmdir           send        size
                 print(ftp.set_debuglevel(int(level)))
             if cmd == command[11]:
                 os.system("clear")
-            if cmd in ('q', 'quit', 'exit'):
+            if cmd in ('q', 'quit', 'exit', 'bye'):
                 return True
             if cmd.split(' ', 1)[0] not in command:
                 print(reminder)


### PR DESCRIPTION
add bye as exit command

add clear to the help menu

add the python3 interpreter so that it doesn't cause errors when executing it without an interpreter from the command line